### PR TITLE
Remove PUBLIC_IP from service port mappings

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -137,7 +137,7 @@ services:
       - /rolling-shutter
       - chain
     ports:
-      - "${PUBLIC_IP}:27656:27656"
+      - "27656:27656"
       - "${METRICS_LISTEN_IP}:27660:27660"
     volumes_from:
       - assets:ro
@@ -171,7 +171,7 @@ services:
     volumes:
       - ./config:/config
     ports:
-      - "${PUBLIC_IP}:24003:24003"
+      - "24003:24003"
       - "${METRICS_LISTEN_IP}:9200:9200"
     depends_on:
       db:


### PR DESCRIPTION
This is an improvement
- when the the docker host is run behind an external firewall, where `PUBLIC_IP` needs to be set to the firewall's IP.
- it allows docker to map the ports on IPv6 and IPv4