### PR TITLE
release/gnosis/2025.12.01 - update rolling shutter version and add release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,13 @@ docker compose -f docker-compose.yml -f docker-compose.loki.yml up -d
 
 ## Version History
 
+### `gnosis/2025.12.01` – `2025-12-31`
+- Upgrade to [Keyper v1.4.0](https://github.com/shutter-network/rolling-shutter/releases/tag/v1.4.0)
+- Fix compatibility for previous eons
+- Fix decryption_key endpoint
+- Fix keyper hanging issue
+- Update handler and middleware to allow no sig on keys message and no check on decryption trigger
+
 ### `gnosis/2025.11.03` – `2025-11-18`
 - Upgrade to [Keyper v1.3.15](https://github.com/shutter-network/rolling-shutter/releases/tag/v1.3.15)
 - Enable keypers to update shuttermint keys

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ x-logging: &logging
     max-file: 10
 
 x-image-main: &image-main
-  image: ${SHUTTER_IMAGE_ROLLING_SHUTTER:-ghcr.io/shutter-network/keyper:v1.3.15}
+  image: ${SHUTTER_IMAGE_ROLLING_SHUTTER:-ghcr.io/shutter-network/keyper:v1.4.0}
 
 x-image-assets: &image-assets
   image: ${SHUTTER_IMAGE_ASSETS:-ghcr.io/shutter-network/assets:shutter-gnosis-1000-set1.4.1}


### PR DESCRIPTION
gnosis release for roling shutter version 1.4.0 mentioned in https://github.com/shutter-network/rolling-shutter/issues/636