### PR TITLE
release: shutter-api-keyper/2026.06.01

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,10 @@ docker compose -f docker-compose.yml -f docker-compose.loki.yml up -d
 
 ## Version History
 
+### `shutter-api-keyper/2026.06.01` – `2026-06-16`
+- Update assets image to shutter-api-gnosis-1002-set1.1.1 in docker-compose.yml
+  - This increases the `MaxNumKeysPerMessage` keyper configuration from 500 to 800.
+
 ### `shutter-api-keyper/2026.04.03` – `2026-04-17`
 - Upgrade to [Keyper v1.4.2](https://github.com/shutter-network/rolling-shutter/releases/tag/v1.4.2)
 - Update chain initialization to support default state initialization when only the validator key is present

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ x-image-main: &image-main
   image: ${SHUTTER_IMAGE_ROLLING_SHUTTER:-ghcr.io/shutter-network/keyper:v1.4.2}
 
 x-image-assets: &image-assets
-  image: ${SHUTTER_IMAGE_ASSETS:-ghcr.io/shutter-network/assets:shutter-api-gnosis-1002-set1.1.0}
+  image: ${SHUTTER_IMAGE_ASSETS:-ghcr.io/shutter-network/assets:shutter-api-gnosis-1002-set1.1.1}
 
 x-image-metrics: &image-metrics
   image: victoriametrics/vmagent:v1.101.0


### PR DESCRIPTION
- Update assets to shutter-api-gnosis-1002-set1.1.1